### PR TITLE
Add dynamic support. Remove Almost Full in fifo. Generate network whe…

### DIFF
--- a/pir/src/codegen/plastiroute/PlastirouteLinkGen.scala
+++ b/pir/src/codegen/plastiroute/PlastirouteLinkGen.scala
@@ -24,6 +24,7 @@ class PlastirouteLinkGen(implicit compiler: PIR) extends PlastisimCodegen with C
       row("count") = n.constCount
       n.out.T.zipWithIndex.foreach { case (gin, idx) =>
         row(s"dst[$idx]") = gin.global.get.id
+        row(s"out[$idx]") = gin.id
       }
     case n => visitNode(n)
   }

--- a/pir/src/codegen/plastisim/PlastisimUtil.scala
+++ b/pir/src/codegen/plastisim/PlastisimUtil.scala
@@ -24,8 +24,6 @@ trait PlastisimUtil extends PIRPass {
   lazy val psimLog = buildPath(psimOut, "psim.log")
   lazy val prouteLog = buildPath(psimOut, "proute.log")
 
-  def noPlaceAndRoute = spadeParam.isAsic || spadeParam.isP2P
-
   val infCount = 1000000
 
   implicit class PIRNodePsimOp(n:PIRNode) {

--- a/pir/src/codegen/tungsten/TungstenTopGen.scala
+++ b/pir/src/codegen/tungsten/TungstenTopGen.scala
@@ -8,6 +8,8 @@ import scala.collection.mutable
 
 trait TungstenTopGen extends TungstenCodegen {
 
+  val dutArgs = mutable.ListBuffer[String]()
+
   override def initPass = {
     super.initPass
     emitln(
@@ -28,12 +30,18 @@ trait TungstenTopGen extends TungstenCodegen {
 #include "bankedsram.h"
 #include "nbuffer.h"
 #include "dramag.h"
+#include "network.h"
 
 #include "hostio.h"
 
 using namespace std;
 
 """)
+
+    if (!noPlaceAndRoute) { //TODO: use spade parameter
+      emitln("""DynamicNetwork<4, 4> net({16, 12}, "net");""")
+      dutArgs += "net"
+    }
 
   }
 
@@ -54,8 +62,6 @@ using namespace std;
     }
     super.finPass
   }
-
-  val dutArgs = mutable.ListBuffer[String]()
 
   final protected def genTop(block: => Unit) = enterFile(outputPath, false)(block)
 

--- a/pir/src/pass/RuntimeAnalyzer.scala
+++ b/pir/src/pass/RuntimeAnalyzer.scala
@@ -8,6 +8,8 @@ import scala.collection.mutable
 
 trait RuntimeAnalyzer { self:PIRPass =>
 
+  def noPlaceAndRoute = spadeParam.isAsic || spadeParam.isP2P 
+
   implicit class CtxUtil(ctx:Context) {
     def reads:Seq[LocalOutAccess] = ctx.collectChildren[LocalOutAccess].filterNot { _.isLocal }
     def writes:Seq[LocalInAccess] = ctx.collectChildren[LocalInAccess].filterNot { _.isLocal }


### PR DESCRIPTION
…n net=hybrid. OuterProduct works

Updated to support dynamic network. Deadlock issue present; possible incorrect arbitration priority.

rebase with master. Remove Almost Full in fifo. Generate network when net=hybrid